### PR TITLE
Implement alternating media/text layout for campaign case study

### DIFF
--- a/campaign_case_study.html
+++ b/campaign_case_study.html
@@ -102,98 +102,77 @@
         </section>
       
         <!-- Campaign 1 -->
-        <article class="campaign email-campaign scroll-fade" data-campaign="romantic-getaway">
-          <h4>Splash Sale</h4>
-          <ul>
-            <li><strong>Subject Line:</strong> 48-Hour Splash Sale!</li>
-            <li><strong>CTA:</strong> Last minute offer! Save 30%</li>
-          </ul>
-      
-          <!-- Performance stats -->
-          <div class="stats">
-        <div class="stat"><strong>22.4%</strong><span>Open Rate</span></div>
-        <div class="stat"><strong>0.63%</strong><span>Click-Through</span></div>
-        <div class="stat"><strong>263</strong><span>Nights Booked</span></div>
-        <div class="stat"><strong>$0.35</strong><span>Revenue / Send</span></div>
-        </div>
-      
-      
-          <!-- Design progression gallery -->
-          <div class="design-progress">
-            <!-- <div class="design-stage">
-              <h5>Wireframe</h5>
-              <img src="assets/email-romantic-wireframe.jpg" alt="Romantic Getaway Email Wireframe">
+        <article class="case-block scroll-fade" data-campaign="romantic-getaway">
+          <div class="case-block__inner">
+            <div class="case-block__copy">
+              <h4>Splash Sale</h4>
+              <ul class="case-block__bullets">
+                <li><strong>Subject Line:</strong> 48-Hour Splash Sale!</li>
+                <li><strong>CTA:</strong> Last minute offer! Save 30%</li>
+              </ul>
+
+              <div class="stats">
+                <div class="stat"><strong>22.4%</strong><span>Open Rate</span></div>
+                <div class="stat"><strong>0.63%</strong><span>Click-Through</span></div>
+                <div class="stat"><strong>263</strong><span>Nights Booked</span></div>
+                <div class="stat"><strong>$0.35</strong><span>Revenue / Send</span></div>
+              </div>
             </div>
-            <div class="design-stage">
-              <h5>Draft</h5>
-              <img src="assets/email-romantic-draft.jpg" alt="Romantic Getaway Email Draft">
-            </div> -->
-            <div class="design-stage">
-              <h5>Final Design</h5>
+
+            <figure class="case-block__media">
               <img src="assets/email-splash-sale.jpg" alt="Splash Sale Final Email Design">
-            </div>
+              <figcaption>Final Design</figcaption>
+            </figure>
           </div>
         </article>
       
         <!-- Campaign 2 Summer Story -->
-        <article class="campaign email-campaign scroll-fade" data-campaign="seasonal-getaway">
-          <h4>Spring is in the Air / Spring Breeze</h4>
-          <ul>
-            <li><strong>Subject Line:</strong> Your Coastal Escape Awaits</li>
-            <li><strong>CTA:</strong> Stay and enjoy the spring breeze.</li>
-          </ul>
-      
-          <div class="stats">
-        <div class="stat"><strong>24.8%</strong><span>Open Rate</span></div>
-        <div class="stat"><strong>0.58%</strong><span>Click-Through</span></div>
-        <div class="stat"><strong>331</strong><span>Nights Booked</span></div>
-        <div class="stat"><strong>$0.39</strong><span>Revenue / Send</span></div>
-        </div>
-      
-          <div class="design-progress">
-            <!-- <div class="design-stage">
-              <h5>Wireframe</h5>
-              <img src="assets/email-seasonal-wireframe.jpg" alt="Seasonal Getaway Email Wireframe">
-            </div> -->
-            <div class="design-stage">
-              <h5>1st email 3/17</h5>
-              <img src="assets/spring-breeze-bridge.jpg" alt="Seasonal Getaway Email Draft">
+        <article class="case-block scroll-fade" data-campaign="seasonal-getaway">
+          <div class="case-block__inner">
+            <div class="case-block__copy">
+              <h4>Spring is in the Air / Spring Breeze</h4>
+              <ul class="case-block__bullets">
+                <li><strong>Subject Line:</strong> Your Coastal Escape Awaits</li>
+                <li><strong>CTA:</strong> Stay and enjoy the spring breeze.</li>
+              </ul>
+
+              <div class="stats">
+                <div class="stat"><strong>24.8%</strong><span>Open Rate</span></div>
+                <div class="stat"><strong>0.58%</strong><span>Click-Through</span></div>
+                <div class="stat"><strong>331</strong><span>Nights Booked</span></div>
+                <div class="stat"><strong>$0.39</strong><span>Revenue / Send</span></div>
+              </div>
             </div>
-            <!-- <div class="design-stage">
-              <h5>2nd email sent 3/19</h5>
-              <img src="assets/spring-is-in-the-air.jpg" alt="Seasonal Getaway Final Email Design">
-            </div> -->
+
+            <figure class="case-block__media">
+              <img src="assets/spring-breeze-bridge.jpg" alt="Seasonal Getaway Email Draft">
+              <figcaption>1st send — March 17</figcaption>
+            </figure>
           </div>
         </article>
       
         <!-- Campaign 3 -->
-        <article class="campaign email-campaign scroll-fade" data-campaign="gift-certificates">
-          <h4>Summer Story</h4>
-          <ul>
-            <li><strong>Subject Line:</strong> Book your Summer Story</li>
-            <li><strong>CTA:</strong> Be the Main Character</li>
-          </ul>
-      
-          <div class="stats">
-            <div class="stat"><strong>23.7%</strong><span>Open Rate</span></div>
-            <div class="stat"><strong>0.54%</strong><span>Click-Through</span></div>
-            <div class="stat"><strong>298</strong><span>Nights Booked</span></div>
-            <div class="stat"><strong>$0.21</strong><span>Revenue / Send</span></div>
-          </div>
-      
-          <div class="design-progress">
-            <!-- <div class="design-stage">
-              <h5>Wireframe</h5>
-              <img src="assets/email-gift-wireframe.jpg" alt="Gift Certificate Email Wireframe">
+        <article class="case-block scroll-fade" data-campaign="gift-certificates">
+          <div class="case-block__inner">
+            <div class="case-block__copy">
+              <h4>Summer Story</h4>
+              <ul class="case-block__bullets">
+                <li><strong>Subject Line:</strong> Book your Summer Story</li>
+                <li><strong>CTA:</strong> Be the Main Character</li>
+              </ul>
+
+              <div class="stats">
+                <div class="stat"><strong>23.7%</strong><span>Open Rate</span></div>
+                <div class="stat"><strong>0.54%</strong><span>Click-Through</span></div>
+                <div class="stat"><strong>298</strong><span>Nights Booked</span></div>
+                <div class="stat"><strong>$0.21</strong><span>Revenue / Send</span></div>
+              </div>
             </div>
-            <div class="design-stage">
-              <h5>Draft</h5>
-              <img src="assets/email-gift-draft.jpg" alt="Gift Certificate Email Draft">
-            </div> -->
-            <div class="design-stage">
-              <h5>Final</h5>
+
+            <figure class="case-block__media">
               <img src="assets/summer-story-promo.png" alt="Summer Story Final Email Design">
-            </div>
+              <figcaption>Final Design</figcaption>
+            </figure>
           </div>
         </article>
       

--- a/index.css
+++ b/index.css
@@ -277,6 +277,110 @@ p{ color:#cbcbd2; }
 .case-study-header h2{ color:#a4b8ff; margin:0 0 6px; font-weight:600; }
 .case-study-header p{ color:#c9c9d2; }
 
+/* 5) CASE STUDY LAYOUT */
+.case-study-wrap{
+  display:flex;
+  flex-direction:column;
+  gap:48px;
+}
+
+.case-block{
+  background:var(--elev);
+  border:1px solid var(--line);
+  border-radius:20px;
+  padding:32px clamp(24px, 4vw, 48px);
+  box-shadow:0 20px 55px rgba(0,0,0,.32);
+}
+
+.case-block__inner{
+  display:flex;
+  flex-direction:column;
+  gap:32px;
+}
+
+.case-block__copy h4{
+  font-size:clamp(22px, 2.8vw, 30px);
+  margin:0 0 14px;
+  color:#f4f4f8;
+}
+
+.case-block__bullets{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  gap:10px;
+  color:#d5d5de;
+}
+
+.case-block__bullets strong{
+  color:#f2f2f9;
+}
+
+.case-block__copy p,
+.case-block__copy li{
+  color:#cfcfd8;
+  font-size:1rem;
+}
+
+.stats{
+  margin-top:26px;
+  display:grid;
+  gap:14px;
+  grid-template-columns:repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.stat{
+  background:rgba(12,12,18,.82);
+  border:1px solid var(--line);
+  border-radius:16px;
+  padding:16px 18px;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);
+}
+
+.stat strong{
+  font-size:1.45rem;
+  font-weight:700;
+  letter-spacing:-0.01em;
+  color:#f8f8fb;
+}
+
+.stat span{
+  font-size:.9rem;
+  color:var(--muted);
+}
+
+.case-block__media{
+  margin:0;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.case-block__media figcaption{
+  font-size:.9rem;
+  color:var(--muted);
+}
+
+@media (min-width: 900px){
+  .case-block__inner{
+    flex-direction:row;
+    align-items:center;
+  }
+
+  .case-block:nth-of-type(even) .case-block__inner{
+    flex-direction:row-reverse;
+  }
+
+  .case-block__copy,
+  .case-block__media{
+    flex:1;
+  }
+}
+
 /* 6) SECTIONS / CARDS */
 .section{ padding:56px var(--pad); max-width:var(--page-max); margin:0 auto; }
 .card, .ibts-case-section{ background:var(--elev); border:1px solid var(--line); border-radius:14px; box-shadow: 0 12px 40px rgba(0,0,0,.30); padding:28px; max-width:var(--page-max); margin:24px auto; }


### PR DESCRIPTION
## Summary
- refactor the campaign case study entries into reusable alternating "case-block" sections
- add supporting styles for alternating layout, stat cards, and figure captions for each campaign image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff7aa78488332961dfc5a66870661